### PR TITLE
Check for get_current_screen before attempting to use it

### DIFF
--- a/global-meta-box-order/index.php
+++ b/global-meta-box-order/index.php
@@ -169,6 +169,10 @@ class MetaBoxOrder {
      * @return WP_Screen|false
      */
     protected function getCurrentScreen() {
+        
+        if ( ! function_exists( 'get_current_screen' ) ) {
+            return false;
+        }
 
         if (defined('DOING_AJAX') && DOING_AJAX) {
 


### PR DESCRIPTION
Fixes a bug where the Wordpress customizer screen will fail with a PHP error if this plugin is installed.

As explained on the official `get_current_screen()` function reference (https://codex.wordpress.org/Function_Reference/get_current_screen):
"This function is defined on most admin pages, but not all. Thus there are cases where is_admin() will return true, but attempting to call get_current_screen() will result in a fatal error because it is not defined. One known example is wp-admin/customize.php."